### PR TITLE
partial fix for 7.4

### DIFF
--- a/src/abstracts/gcontainer.c
+++ b/src/abstracts/gcontainer.c
@@ -131,7 +131,7 @@ HashTable *gcontainer_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gcontainer_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gcontainer_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	gwidget_ptr w = intern->widget_ptr;
 	long tmp_l;
@@ -143,11 +143,12 @@ void gcontainer_write_property(zval *object, zval *member, zval *value, void **c
 			if(!strcmp(member_val, GCONTAINER_BORDER_WIDTH))
 				gtk_container_set_border_width(GTK_CONTAINER(w->intern), tmp_l);
 			else
-				gwidget_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gwidget_write_property(object, member, value, cache_slot));
 			break;
 		default:
-			gwidget_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(gwidget_write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 

--- a/src/abstracts/gcontainer.h
+++ b/src/abstracts/gcontainer.h
@@ -58,7 +58,7 @@ zval *gcontainer_read_property(zval *object, zval *member, int type, void **cach
 
 HashTable *gcontainer_get_properties(zval *object);
 
-void gcontainer_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gcontainer_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 /***********************************/
 /* GContainer class initialisation */

--- a/src/abstracts/gmenushell.c
+++ b/src/abstracts/gmenushell.c
@@ -117,7 +117,7 @@ HashTable *gmenushell_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gmenushell_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gmenushell_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	gwidget_ptr w = intern->widget_ptr;
 	int tmp_b;
@@ -131,11 +131,12 @@ void gmenushell_write_property(zval *object, zval *member, zval *value, void **c
 			if(!strcmp(member_val, GMENUSHELL_TAKE_FOCUS))
 				gtk_menu_shell_set_take_focus(menu, tmp_b);
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		default :
-			gcontainer_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /***********************************/

--- a/src/abstracts/gmenushell.h
+++ b/src/abstracts/gmenushell.h
@@ -55,7 +55,7 @@ HashTable *row_get_properties(zval *object);
 /** 
  * Write property handling function
  */
-void gmenushell_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gmenushell_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 
 /***************/

--- a/src/abstracts/gwidget.c
+++ b/src/abstracts/gwidget.c
@@ -526,7 +526,7 @@ HashTable *gwidget_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gwidget_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gwidget_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	gwidget_ptr w = intern->widget_ptr;
 	long tmp_l;
@@ -587,7 +587,7 @@ void gwidget_write_property(zval *object, zval *member, zval *value, void **cach
 						break;
 				}
 			else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		case IS_FALSE :
 		case IS_TRUE :
@@ -613,14 +613,14 @@ void gwidget_write_property(zval *object, zval *member, zval *value, void **cach
 			else if(!strcmp(member_val, GWIDGET_SENSITIVE))
 				gtk_widget_set_sensitive(w->intern, tmp_b);
 			else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		case IS_STRING :
 			tmp_s = Z_STRVAL_P(value);
 			if(!strcmp(Z_STRVAL_P(member), GWIDGET_NAME))
 				gtk_widget_set_name(w->intern, tmp_s);
 			else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		case IS_DOUBLE :
 			tmp_d = Z_DVAL_P(value);
@@ -630,11 +630,12 @@ void gwidget_write_property(zval *object, zval *member, zval *value, void **cach
 				else
 				zend_throw_exception_ex(pggi_exception_get(), 0, "the opacity property should be between 0 and 1");
 			}else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		default:
-			std_object_handlers.write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /********************************/

--- a/src/abstracts/gwidget.h
+++ b/src/abstracts/gwidget.h
@@ -219,7 +219,7 @@ HashTable *gwidget_get_properties(zval *object);
 /** 
  * write property handling function
  */
-void gwidget_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gwidget_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 /********************************/
 /* GWidget Class Initialization */

--- a/src/applications/gwindow.c
+++ b/src/applications/gwindow.c
@@ -194,7 +194,7 @@ HashTable *gwindow_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gwindow_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gwindow_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	gwidget_ptr w = intern->widget_ptr;
 	int tmp_b;
@@ -206,7 +206,7 @@ void gwindow_write_property(zval *object, zval *member, zval *value, void **cach
 			if(!strcmp(member_val, GWINDOW_TITLE))
 				gtk_window_set_title(win, Z_STRVAL_P(value));
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_TRUE :
 		case IS_FALSE :
@@ -228,11 +228,12 @@ void gwindow_write_property(zval *object, zval *member, zval *value, void **cach
 			else if(!strcmp(member_val, GWINDOW_ACCEPT_FOCUS))
 				gtk_window_set_accept_focus(win, tmp_b);
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		default :
-			gcontainer_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /********************************/

--- a/src/applications/gwindow.h
+++ b/src/applications/gwindow.h
@@ -81,7 +81,7 @@ HashTable * gwindow_get_properties(zval *object);
 /** 
  * Write property handling function
  */
-void gwindow_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gwindow_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 
 /***************/

--- a/src/buttons/gbutton.c
+++ b/src/buttons/gbutton.c
@@ -135,7 +135,7 @@ HashTable *gbutton_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gbutton_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gbutton_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	ze_gwidget_object * tmp_widget;
 	gwidget_ptr w = intern->widget_ptr;
@@ -149,7 +149,7 @@ void gbutton_write_property(zval *object, zval *member, zval *value, void **cach
 			if(!strcmp(Z_STRVAL_P(member), GBUTTON_LABEL))
 				gtk_button_set_label(but, Z_STRVAL_P(value));
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_LONG :
 			tmp_l = Z_LVAL_P(value);
@@ -174,7 +174,7 @@ void gbutton_write_property(zval *object, zval *member, zval *value, void **cach
 						zend_throw_exception_ex(pggi_exception_get(), 0, "Can't change the relief property. New value should be a RELIEF_*");
 				}
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_TRUE  :
 		case IS_FALSE :
@@ -184,7 +184,7 @@ void gbutton_write_property(zval *object, zval *member, zval *value, void **cach
 			else if(!strcmp(member_val, GBUTTON_USE_UNDERLINE))
 				gtk_button_set_use_underline(but, tmp_b);
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_OBJECT :
 				if(!strcmp(member_val, GBUTTON_IMAGE)){
@@ -194,14 +194,15 @@ void gbutton_write_property(zval *object, zval *member, zval *value, void **cach
 						return ;
 					}
 					w = tmp_widget->widget_ptr;
-					std_object_handlers.write_property(object, member, value, cache_slot);
 					gtk_button_set_image(but, w->intern);
+					PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 				}else
-					gcontainer_write_property(object, member, value, cache_slot);
+					PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		default :
-			gcontainer_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 

--- a/src/buttons/gbutton.h
+++ b/src/buttons/gbutton.h
@@ -35,7 +35,7 @@ PHP_METHOD(GButton, __construct);
 
 zval *gbutton_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv);
 HashTable *gbutton_get_properties(zval *object);
-void gbutton_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gbutton_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 void gbutton_init(int module_number);
 

--- a/src/cairo/imagesurface.c
+++ b/src/cairo/imagesurface.c
@@ -210,7 +210,7 @@ HashTable *pc_image_surface_get_properties(zval *object){
 	return pc_surface_get_properties(object);
 }
 
-void pc_image_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE pc_image_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	/*ze_surface_object * intern = Z_SURFACE_P(object);
 	pc_surface_ptr c = intern->surface_ptr;
 
@@ -219,7 +219,7 @@ void pc_image_surface_write_property(zval *object, zval *member, zval *value, vo
 	switch(Z_TYPE_P(value)){
 		
 		default:
-			pc_surface_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(pc_surface_write_property(object, member, value, cache_slot));
 	}
 }
 

--- a/src/cairo/imagesurface.h
+++ b/src/cairo/imagesurface.h
@@ -100,7 +100,7 @@ HashTable *pc_image_surface_get_properties(zval *object);
 /** 
  * write property handling function
  */
-void pc_image_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE pc_image_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 /************************/
 /* Class Initialization */

--- a/src/cairo/pattern.c
+++ b/src/cairo/pattern.c
@@ -114,7 +114,7 @@ HashTable *pc_pattern_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void pc_pattern_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE pc_pattern_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_pattern_object * intern = Z_PATTERN_P(object);
 	pc_pattern_ptr c = intern->pattern_ptr;
 	long tmp_l;
@@ -134,7 +134,7 @@ void pc_pattern_write_property(zval *object, zval *member, zval *value, void **c
 						break;
 					default:
 						zend_throw_exception_ex(pggi_exception_get(), 0, "Can't change the filter property, needs to be a Pattern::FILTER_*");
-						return;
+						PHP_WRITE_PROP_HANDLER_RETURN(value);
 						break;
 				}
 			}else if(!strcmp(member_val, PATTERN_EXTEND)){
@@ -145,16 +145,17 @@ void pc_pattern_write_property(zval *object, zval *member, zval *value, void **c
 						break;
 					default:
 						zend_throw_exception_ex(pggi_exception_get(), 0, "Can't change the extend property, needs to be a Pattern::EXTEND_*");
-						return;
+						PHP_WRITE_PROP_HANDLER_RETURN(value);
 						break;
 				}
 			}else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		default:
-			std_object_handlers.write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 	}
 	pc_exception(cairo_pattern_status(c->intern));
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /********************************/

--- a/src/cairo/pattern.h
+++ b/src/cairo/pattern.h
@@ -111,7 +111,7 @@ HashTable *pc_pattern_get_properties(zval *object);
 /** 
  * write property handling function
  */
-void pc_pattern_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE pc_pattern_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 /************************/
 /* Class Initialization */

--- a/src/cairo/pattern_surface.c
+++ b/src/cairo/pattern_surface.c
@@ -70,7 +70,7 @@ static const zend_function_entry pc_pattern_surface_class_functions[] = {
 };
 
 
-void pc_pattern_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE pc_pattern_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_pattern_object * intern = Z_PATTERN_P(object);
 	pc_pattern_ptr c = intern->pattern_ptr;
 	long tmp_l;
@@ -89,16 +89,17 @@ void pc_pattern_surface_write_property(zval *object, zval *member, zval *value, 
 						break;
 					default:
 						zend_throw_exception_ex(pggi_exception_get(), 0, "Can't change the extend property, needs to be a Pattern::EXTEND_*");
-						return;
+						PHP_WRITE_PROP_HANDLER_RETURN(value);
 						break;
 				}
 			}else
-				std_object_handlers.write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 			break;
 		default:
-			std_object_handlers.write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 	}
 	pc_exception(cairo_pattern_status(c->intern));
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /********************************/

--- a/src/cairo/surface.c
+++ b/src/cairo/surface.c
@@ -146,7 +146,7 @@ HashTable *pc_surface_get_properties(zval *object){
 	return zend_std_get_properties(object);
 }
 
-void pc_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE pc_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	/*ze_surface_object * intern = Z_SURFACE_P(object);
 	pc_surface_ptr c = intern->surface_ptr;
 
@@ -154,7 +154,7 @@ void pc_surface_write_property(zval *object, zval *member, zval *value, void **c
 	char * member_val = Z_STRVAL_P(member);*/
 	switch(Z_TYPE_P(value)){
 		default:
-			std_object_handlers.write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 	}
 }
 

--- a/src/cairo/surface.h
+++ b/src/cairo/surface.h
@@ -137,7 +137,7 @@ HashTable *pc_surface_get_properties(zval *object);
 /** 
  * write property handling function
  */
-void pc_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE pc_surface_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 /************************/
 /* Class Initialization */

--- a/src/commons/hub.h
+++ b/src/commons/hub.h
@@ -28,6 +28,15 @@
 
 #endif
 
+#if PHP_VERSION_ID >= 70400
+#	define PHP_WRITE_PROP_HANDLER_TYPE zval *
+#	define PHP_WRITE_PROP_HANDLER_RETURN(v) return v
+#else
+#	define PHP_WRITE_PROP_HANDLER_TYPE void
+#	define PHP_WRITE_PROP_HANDLER_RETURN(v) (void)v; return
+#endif
+
+
 
 /**
  * This file is meant to provide common informations for all our classes

--- a/src/menus/gmenuitem.c
+++ b/src/menus/gmenuitem.c
@@ -163,7 +163,7 @@ HashTable *gmenuitem_get_properties(zval *object){
 	return G_H_UPDATE_RETURN;
 }
 
-void gmenuitem_write_property(zval *object, zval *member, zval *value, void **cache_slot){
+PHP_WRITE_PROP_HANDLER_TYPE gmenuitem_write_property(zval *object, zval *member, zval *value, void **cache_slot){
 	ze_gwidget_object * intern = Z_GWIDGET_P(object);
 	gwidget_ptr w = intern->widget_ptr;
 	ze_gwidget_object * tmp_obj;
@@ -178,7 +178,7 @@ void gmenuitem_write_property(zval *object, zval *member, zval *value, void **ca
 			else if(!strcmp(member_val, GMENUITEM_ACCEL_PATH))
 				gtk_menu_item_set_accel_path(menu, Z_STRVAL_P(value));
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_FALSE :
 		case IS_TRUE  :
@@ -188,24 +188,25 @@ void gmenuitem_write_property(zval *object, zval *member, zval *value, void **ca
 			else if(!strcmp(member_val, GMENUITEM_RESERVE_INDICATOR))
 				gtk_menu_item_set_reserve_indicator(menu, tmp_b);
 			else
-				gcontainer_write_property(object, member, value, cache_slot);
+				PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		case IS_OBJECT :
 				if(!strcmp(member_val, GMENUITEM_SUBMENU)){
 					tmp_obj = Z_GWIDGET_P(value);
 					if(!tmp_obj){
 						zend_throw_exception_ex(pggi_exception_get(), 0, "the submenu need to be a widget");
-						return ;
+						PHP_WRITE_PROP_HANDLER_RETURN(value);
 					}
 					w = tmp_obj->widget_ptr;
-					std_object_handlers.write_property(object, member, value, cache_slot);
+					PHP_WRITE_PROP_HANDLER_RETURN(std_object_handlers.write_property(object, member, value, cache_slot));
 					gtk_menu_item_set_submenu(menu, w->intern);
 				}else
-					gcontainer_write_property(object, member, value, cache_slot);
+					PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 			break;
 		default :
-			gcontainer_write_property(object, member, value, cache_slot);
+			PHP_WRITE_PROP_HANDLER_RETURN(gcontainer_write_property(object, member, value, cache_slot));
 	}
+	PHP_WRITE_PROP_HANDLER_RETURN(value);
 }
 
 /**********************************/

--- a/src/menus/gmenuitem.h
+++ b/src/menus/gmenuitem.h
@@ -63,7 +63,7 @@ HashTable *gmenuitem_get_properties(zval *object);
 /** 
  * Write property handling function
  */
-void gmenuitem_write_property(zval *object, zval *member, zval *value, void **cache_slot);
+PHP_WRITE_PROP_HANDLER_TYPE gmenuitem_write_property(zval *object, zval *member, zval *value, void **cache_slot);
 
 
 /***************/


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
  m. The write_property() object handler now returns the assigned value (after
     possible type coercions) rather than void. For extensions, it should
     usually be sufficient to return whatever was passed as the argument.

```

I fix some.... only to show a possible fix, feel free to apply and fix the others, or fix all in a different way.

So mostly a "head-up"
